### PR TITLE
fix: do registration only once

### DIFF
--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -4,7 +4,9 @@ import SwiftUI
 struct ExampleApp: App {
 	var body: some Scene {
 		WindowGroup {
-			ContentView()
+			NavigationStack {
+				ContentView()
+			}
 		}
 	}
 }

--- a/Sources/FluentIcon/Shared/FluentIconFont.swift
+++ b/Sources/FluentIcon/Shared/FluentIconFont.swift
@@ -6,8 +6,8 @@ enum FluentIconFont: String, FluentFont, CaseIterable {
 	case light = "FluentSystemIcons-Light"
 	case resizable = "FluentSystemIcons-Resizable"
 
-	public var file: String { rawValue }
-	public var name: String { file }
+	var file: String { rawValue }
+	var name: String { file }
 
 	var description: String {
 		switch self {

--- a/Sources/FluentIcon/Shared/FontRegistration.swift
+++ b/Sources/FluentIcon/Shared/FontRegistration.swift
@@ -2,15 +2,20 @@ import CoreGraphics
 import CoreText
 import Foundation
 
-public enum FontRegistration {
-	public static func registerFonts(from bundle: Bundle? = nil) {
+enum FontRegistration {
+	fileprivate static let registration = Registration()
+
+	internal static func registerFonts(from bundle: Bundle? = nil) {
 		#if SWIFT_PACKAGE
 		let fontBundle = bundle ?? Bundle.module
 		#else
 		let fontBundle = bundle ?? Bundle(for: Self.self)
 		#endif
-		FluentIconFont.allCases.forEach { font in
-			registerFont(bundle: fontBundle, fontName: font.file, fontExtension: "ttf")
+
+		registration.doRegister {
+			FluentIconFont.allCases.forEach { font in
+				registerFont(bundle: fontBundle, fontName: font.file, fontExtension: "ttf")
+			}
 		}
 	}
 
@@ -22,5 +27,54 @@ public enum FontRegistration {
 		else { return }
 		// ignore error
 		CTFontManagerRegisterGraphicsFont(font, nil)
+	}
+}
+
+extension FontRegistration {
+	fileprivate final class Registration: @unchecked Sendable {
+		private let lock: UnfairLock = .init()
+		private(set) var isRegistered = false
+
+		func doRegister(_ operation: () -> Void) {
+			guard !isRegistered else { return }
+			lock.around {
+				guard !isRegistered else { return }
+				operation()
+				isRegistered = true
+			}
+		}
+	}
+
+	final class UnfairLock {
+		private let unfairLock: os_unfair_lock_t
+
+		init() {
+			self.unfairLock = .allocate(capacity: 1)
+			unfairLock.initialize(to: os_unfair_lock())
+		}
+
+		deinit {
+			unfairLock.deinitialize(count: 1)
+			unfairLock.deallocate()
+		}
+
+		@discardableResult
+		func around<T>(_ closure: () throws -> T) rethrows -> T {
+			lock(); defer { unlock() }
+			return try closure()
+		}
+
+		func around(_ closure: () throws -> Void) rethrows {
+			lock(); defer { unlock() }
+			return try closure()
+		}
+
+		private func lock() {
+			os_unfair_lock_lock(unfairLock)
+		}
+
+		private func unlock() {
+			os_unfair_lock_unlock(unfairLock)
+		}
 	}
 }

--- a/Tests/FluentIconTests/UnfairLockTests.swift
+++ b/Tests/FluentIconTests/UnfairLockTests.swift
@@ -1,0 +1,57 @@
+@testable import FluentIcon
+import XCTest
+
+final class UnfairLockTests: XCTestCase {
+	typealias UnfairLock = FontRegistration.UnfairLock
+
+	func testAroundReturnsValue() throws {
+		let lock = UnfairLock()
+		let result = lock.around {
+			42
+		}
+		XCTAssertEqual(result, 42)
+	}
+
+	func testAroundThrowsError() {
+		enum TestError: Error { case failure }
+		let lock = UnfairLock()
+		XCTAssertThrowsError(try lock.around {
+			throw TestError.failure
+		}) { error in
+			XCTAssertEqual(error as? TestError, TestError.failure)
+		}
+	}
+
+	func testAroundExecutesClosure() throws {
+		let lock = UnfairLock()
+		var executed = false
+		lock.around {
+			executed = true
+		}
+		XCTAssertTrue(executed)
+	}
+
+	func testAroundVoidThrowsError() {
+		enum TestError: Error { case failure }
+		let lock = UnfairLock()
+		XCTAssertThrowsError(try lock.around {
+			throw TestError.failure
+		}) { error in
+			XCTAssertEqual(error as? TestError, TestError.failure)
+		}
+	}
+
+	func testLockUnlockMechanism() {
+		let lock = UnfairLock()
+		var counter = 0
+		let roundCount = 999
+
+		DispatchQueue.concurrentPerform(iterations: roundCount) { _ in
+			lock.around {
+				counter += 1
+			}
+		}
+
+		XCTAssertEqual(counter, roundCount)
+	}
+}


### PR DESCRIPTION
Items in this PR
- [x] resolve registration duplicate error in console only
- [x] register font only once by using flag with lock